### PR TITLE
Add simple mode options dictionary for OS version and due date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `simpleModeOptions` dictionary lets you toggle `showRequiredOSVersion` and `showRequiredDate` while keeping `simpleMode` as a top-level boolean
+
 ## [2.0.12] - 2024-09-18
 Requires macOS 12.0 and higher.
 

--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -75,6 +75,10 @@
         "screenShotLightPath": "/somewhere/screenShotLight.png",
         "showDeferralCount": true,
         "simpleMode": false,
+        "simpleModeOptions": {
+            "showRequiredDate": true,
+            "showRequiredOSVersion": true
+        },
         "singleQuitButton": false,
         "updateElements": [
             {

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -157,8 +157,17 @@
                     <string>/somewhere/screenShotLight.png</string>
                     <key>showDeferralCount</key>
                     <true/>
+                    <key>showRequiredDate</key>
+                    <true/>
                     <key>simpleMode</key>
                     <false/>
+                    <key>simpleModeOptions</key>
+                    <dict>
+                        <key>showRequiredDate</key>
+                        <true/>
+                        <key>showRequiredOSVersion</key>
+                        <true/>
+                    </dict>
                     <key>singleQuitButton</key>
                     <false/>
                     <key>updateElements</key>

--- a/Example Assets/com.github.macadmins.Nudge.tester.json
+++ b/Example Assets/com.github.macadmins.Nudge.tester.json
@@ -22,6 +22,12 @@
         "screenShotDarkPath": "https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_dark_1_icon.png?raw=true",
         "screenShotLightPath": "https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_light_1_icon.png?raw=true",
         "applicationTerminatedNotificationImagePath": "/Library/Application Support/Nudge/logoLight.png",
+        "showRequiredDate": true,
+        "simpleMode": false,
+        "simpleModeOptions": {
+            "showRequiredDate": true,
+            "showRequiredOSVersion": true
+        },
         "updateElements": [
             {
                 "_language": "en",

--- a/Example Assets/com.github.macadmins.Nudge.tester.plist
+++ b/Example Assets/com.github.macadmins.Nudge.tester.plist
@@ -59,14 +59,23 @@
 		<string>https://github.com/macadmins/nudge/blob/main/assets/NudgeIconInverted.png?raw=true</string>
 		<key>iconLightPath</key>
 		<string>https://github.com/macadmins/nudge/blob/main/assets/NudgeIcon.png?raw=true</string>
-		<key>screenShotDarkPath</key>
-		<string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_dark_1_icon.png?raw=true</string>
-		<key>screenShotLightPath</key>
-		<string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_light_1_icon.png?raw=true</string>
-		<key>simpleMode</key>
-		<false/>
-		<key>updateElements</key>
-		<array>
+                <key>screenShotDarkPath</key>
+                <string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_dark_1_icon.png?raw=true</string>
+                <key>screenShotLightPath</key>
+                <string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_light_1_icon.png?raw=true</string>
+                <key>showRequiredDate</key>
+                <true/>
+                <key>simpleMode</key>
+                <false/>
+                <key>simpleModeOptions</key>
+                <dict>
+                        <key>showRequiredDate</key>
+                        <true/>
+                        <key>showRequiredOSVersion</key>
+                        <true/>
+                </dict>
+                <key>updateElements</key>
+                <array>
 			<dict>
 				<key>_language</key>
 				<string>en</string>

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -626,6 +626,31 @@ struct UserInterfaceVariables {
         false
     }
 
+    static var simpleModeEnabled: Bool {
+        if let simpleMode = userInterfaceProfile?["simpleMode"] as? Bool {
+            return simpleMode
+        }
+        return userInterfaceJSON?.simpleMode ?? false
+    }
+
+    static var simpleModeShowRequiredDate: Bool {
+        guard simpleModeEnabled else { return false }
+        if let options = userInterfaceProfile?["simpleModeOptions"] as? [String: Any],
+           let value = options["showRequiredDate"] as? Bool {
+            return value
+        }
+        return userInterfaceJSON?.simpleModeOptions?.showRequiredDate ?? false
+    }
+
+    static var simpleModeShowRequiredOSVersion: Bool {
+        guard simpleModeEnabled else { return false }
+        if let options = userInterfaceProfile?["simpleModeOptions"] as? [String: Any],
+           let value = options["showRequiredOSVersion"] as? Bool {
+            return value
+        }
+        return userInterfaceJSON?.simpleModeOptions?.showRequiredOSVersion ?? false
+    }
+
     static var singleQuitButton: Bool {
         userInterfaceProfile?["singleQuitButton"] as? Bool ??
         userInterfaceJSON?.singleQuitButton ??

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -458,8 +458,13 @@ struct UserInterface: Codable {
     var actionButtonPath, applicationTerminatedNotificationImagePath, fallbackLanguage: String?
     var forceFallbackLanguage, forceScreenShotIcon: Bool?
     var iconDarkPath, iconLightPath, requiredInstallationDisplayFormat, screenShotDarkPath, screenShotLightPath: String?
-    var showActivelyExploitedCVEs, showDeferralCount, showDaysRemainingToUpdate, showRequiredDate, simpleMode, singleQuitButton: Bool?
+    var showActivelyExploitedCVEs, showDeferralCount, showDaysRemainingToUpdate, showRequiredDate, singleQuitButton: Bool?
+    var simpleMode: Bool?
+    var simpleModeOptions: SimpleModeOptions?
     var updateElements: [UpdateElement]?
+}
+struct SimpleModeOptions: Codable {
+    var showRequiredDate, showRequiredOSVersion: Bool?
 }
 
 // MARK: UserInterface convenience initializers and mutators
@@ -496,6 +501,7 @@ extension UserInterface {
         showDaysRemainingToUpdate: Bool? = nil,
         showRequiredDate: Bool? = nil,
         simpleMode: Bool? = nil,
+        simpleModeOptions: SimpleModeOptions? = nil,
         singleQuitButton: Bool? = nil,
         updateElements: [UpdateElement]? = nil
     ) -> UserInterface {
@@ -515,6 +521,7 @@ extension UserInterface {
             showDaysRemainingToUpdate: showDaysRemainingToUpdate ?? self.showDaysRemainingToUpdate,
             showRequiredDate: showRequiredDate ?? self.showRequiredDate,
             simpleMode: simpleMode ?? self.simpleMode,
+            simpleModeOptions: simpleModeOptions ?? self.simpleModeOptions,
             singleQuitButton: singleQuitButton ?? self.singleQuitButton,
             updateElements: updateElements ?? self.updateElements
         )

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -505,27 +505,47 @@ extension UserInterface {
         singleQuitButton: Bool? = nil,
         updateElements: [UpdateElement]? = nil
     ) -> UserInterface {
+        let actionButtonPath = actionButtonPath ?? self.actionButtonPath
+        let applicationTerminatedNotificationImagePath = applicationTerminatedNotificationImagePath ?? self.applicationTerminatedNotificationImagePath
+        let fallbackLanguage = fallbackLanguage ?? self.fallbackLanguage
+        let forceFallbackLanguage = forceFallbackLanguage ?? self.forceFallbackLanguage
+        let forceScreenShotIcon = forceScreenShotIcon ?? self.forceScreenShotIcon
+        let iconDarkPath = iconDarkPath ?? self.iconDarkPath
+        let iconLightPath = iconLightPath ?? self.iconLightPath
+        let requiredInstallationDisplayFormat = requiredInstallationDisplayFormat ?? self.requiredInstallationDisplayFormat
+        let screenShotDarkPath = screenShotDarkPath ?? self.screenShotDarkPath
+        let screenShotLightPath = screenShotLightPath ?? self.screenShotLightPath
+        let showActivelyExploitedCVEs = showActivelyExploitedCVEs ?? self.showActivelyExploitedCVEs
+        let showDeferralCount = showDeferralCount ?? self.showDeferralCount
+        let showDaysRemainingToUpdate = showDaysRemainingToUpdate ?? self.showDaysRemainingToUpdate
+        let showRequiredDate = showRequiredDate ?? self.showRequiredDate
+        let simpleMode = simpleMode ?? self.simpleMode
+        let simpleModeOptions = simpleModeOptions ?? self.simpleModeOptions
+        let singleQuitButton = singleQuitButton ?? self.singleQuitButton
+        let updateElements = updateElements ?? self.updateElements
+
         return UserInterface(
-            actionButtonPath: actionButtonPath ?? self.actionButtonPath,
-            applicationTerminatedNotificationImagePath: applicationTerminatedNotificationImagePath ?? self.applicationTerminatedNotificationImagePath,
-            fallbackLanguage: fallbackLanguage ?? self.fallbackLanguage,
-            forceFallbackLanguage: forceFallbackLanguage ?? self.forceFallbackLanguage,
-            forceScreenShotIcon: forceScreenShotIcon ?? self.forceScreenShotIcon,
-            iconDarkPath: iconDarkPath ?? self.iconDarkPath,
-            iconLightPath: iconLightPath ?? self.iconLightPath,
-            requiredInstallationDisplayFormat: requiredInstallationDisplayFormat ?? self.requiredInstallationDisplayFormat,
-            screenShotDarkPath: screenShotDarkPath ?? self.screenShotDarkPath,
-            screenShotLightPath: screenShotLightPath ?? self.screenShotLightPath,
-            showActivelyExploitedCVEs: showActivelyExploitedCVEs ?? self.showActivelyExploitedCVEs,
-            showDeferralCount: showDeferralCount ?? self.showDeferralCount,
-            showDaysRemainingToUpdate: showDaysRemainingToUpdate ?? self.showDaysRemainingToUpdate,
-            showRequiredDate: showRequiredDate ?? self.showRequiredDate,
-            simpleMode: simpleMode ?? self.simpleMode,
-            simpleModeOptions: simpleModeOptions ?? self.simpleModeOptions,
-            singleQuitButton: singleQuitButton ?? self.singleQuitButton,
-            updateElements: updateElements ?? self.updateElements
+            actionButtonPath: actionButtonPath,
+            applicationTerminatedNotificationImagePath: applicationTerminatedNotificationImagePath,
+            fallbackLanguage: fallbackLanguage,
+            forceFallbackLanguage: forceFallbackLanguage,
+            forceScreenShotIcon: forceScreenShotIcon,
+            iconDarkPath: iconDarkPath,
+            iconLightPath: iconLightPath,
+            requiredInstallationDisplayFormat: requiredInstallationDisplayFormat,
+            screenShotDarkPath: screenShotDarkPath,
+            screenShotLightPath: screenShotLightPath,
+            showActivelyExploitedCVEs: showActivelyExploitedCVEs,
+            showDeferralCount: showDeferralCount,
+            showDaysRemainingToUpdate: showDaysRemainingToUpdate,
+            showRequiredDate: showRequiredDate,
+            singleQuitButton: singleQuitButton,
+            simpleMode: simpleMode,
+            simpleModeOptions: simpleModeOptions,
+            updateElements: updateElements
         )
     }
+
 }
 
 // MARK: - UpdateElement

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -32,7 +32,15 @@ struct SimpleMode: View {
             
             Text(appState.deviceSupportedByOSVersion ? getMainHeader().localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)) : getMainHeaderUnsupported().localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
                 .font(.title)
-            
+
+            if UserInterfaceVariables.simpleModeShowRequiredOSVersion {
+                requiredOSVersionView
+            }
+
+            if UserInterfaceVariables.simpleModeShowRequiredDate {
+                requiredDateView
+            }
+
             remainingTimeView
 
             if UserInterfaceVariables.showDeferralCount {
@@ -83,6 +91,22 @@ struct SimpleMode: View {
             Text(String(appState.userDeferrals))
                 .foregroundColor(infoTextColor)
                 .font(.title2)
+        }
+    }
+
+    private var requiredOSVersionView: some View {
+        HStack {
+            Text("Required OS Version:".localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
+            Text(String(appState.requiredMinimumOSVersion))
+                .foregroundColor(infoTextColor)
+        }
+    }
+
+    private var requiredDateView: some View {
+        HStack {
+            Text("Required Date:".localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
+            Text(DateManager().coerceDateToString(date: requiredInstallationDate, formatterString: UserInterfaceVariables.requiredInstallationDisplayFormat))
+                .foregroundColor(infoTextColor)
         }
     }
     

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -391,6 +391,5 @@ func getMainHeaderUnsupported() -> String {
 
 func simpleMode() -> Bool {
     return CommandLineUtilities().simpleModeEnabled() ||
-    UserInterfaceVariables.userInterfaceProfile?["simpleMode"] as? Bool ??
-    Globals.nudgeJSONPreferences?.userInterface?.simpleMode ?? false
+    UserInterfaceVariables.simpleModeEnabled
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For more information about installation, deployment, and the user experience, pl
 
 # Examples of the User Interface
 ## simpleMode
+SimpleMode offers a streamlined experience and can optionally display the required OS version and due date. Enable simple mode with the top-level `simpleMode` key and configure the `simpleModeOptions` dictionary with `showRequiredOSVersion` and `showRequiredDate` keys to control this behavior.
 ### English
 #### Light
 <img src="/assets/simple_mode/demo_simple_light_1.png" width=75% height=75%>

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -1451,6 +1451,40 @@
                                 }
                             ]
                         },
+                        "simpleModeOptions": {
+                            "description": "Configuration options for the simplified user experience.",
+                            "type": "object",
+                            "properties": {
+                                "showRequiredDate": {
+                                    "description": "When enabled, Nudge will show the requiredInstallationDate when using simpleMode.",
+                                    "anyOf": [
+                                        {
+                                            "title": "Not Configured",
+                                            "type": "null"
+                                        },
+                                        {
+                                            "title": "Configured",
+                                            "default": false,
+                                            "type": "boolean"
+                                        }
+                                    ]
+                                },
+                                "showRequiredOSVersion": {
+                                    "description": "When enabled, Nudge will show the requiredMinimumOSVersion when using simpleMode.",
+                                    "anyOf": [
+                                        {
+                                            "title": "Not Configured",
+                                            "type": "null"
+                                        },
+                                        {
+                                            "title": "Configured",
+                                            "default": false,
+                                            "type": "boolean"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
                         "singleQuitButton": {
                             "description": "Only display one quit button regardless of proximity to the due date.",
                             "anyOf": [


### PR DESCRIPTION
## Summary
- keep `simpleMode` as a top-level boolean for backward compatibility
- add `simpleModeOptions` dictionary with `showRequiredOSVersion` and `showRequiredDate`
- adjust preference helpers, schema, examples, and documentation accordingly

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -project Nudge.xcodeproj -scheme Nudge build | head -n 20` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_i_68992140bf78832baa5da9bf856f57f7