### PR TITLE
Add simple mode options dictionary for OS version and due date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `simpleModeOptions` dictionary lets you toggle `showRequiredOSVersion`, `showRequiredDate`, and `showRequiredTime` while keeping `simpleMode` as a top-level boolean
+
 ## [2.0.12] - 2024-09-18
 Requires macOS 12.0 and higher.
 

--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -75,6 +75,11 @@
         "screenShotLightPath": "/somewhere/screenShotLight.png",
         "showDeferralCount": true,
         "simpleMode": false,
+        "simpleModeOptions": {
+            "showRequiredDate": true,
+            "showRequiredOSVersion": true,
+            "showRequiredTime": true
+        },
         "singleQuitButton": false,
         "updateElements": [
             {

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -157,8 +157,19 @@
                     <string>/somewhere/screenShotLight.png</string>
                     <key>showDeferralCount</key>
                     <true/>
+                    <key>showRequiredDate</key>
+                    <true/>
                     <key>simpleMode</key>
                     <false/>
+                    <key>simpleModeOptions</key>
+                    <dict>
+                        <key>showRequiredDate</key>
+                        <true/>
+                        <key>showRequiredOSVersion</key>
+                        <true/>
+                        <key>showRequiredTime</key>
+                        <true/>
+                    </dict>
                     <key>singleQuitButton</key>
                     <false/>
                     <key>updateElements</key>

--- a/Example Assets/com.github.macadmins.Nudge.tester.json
+++ b/Example Assets/com.github.macadmins.Nudge.tester.json
@@ -22,6 +22,13 @@
         "screenShotDarkPath": "https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_dark_1_icon.png?raw=true",
         "screenShotLightPath": "https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_light_1_icon.png?raw=true",
         "applicationTerminatedNotificationImagePath": "/Library/Application Support/Nudge/logoLight.png",
+        "showRequiredDate": true,
+        "simpleMode": false,
+        "simpleModeOptions": {
+            "showRequiredDate": true,
+            "showRequiredOSVersion": true,
+            "showRequiredTime": true
+        },
         "updateElements": [
             {
                 "_language": "en",

--- a/Example Assets/com.github.macadmins.Nudge.tester.plist
+++ b/Example Assets/com.github.macadmins.Nudge.tester.plist
@@ -59,14 +59,25 @@
 		<string>https://github.com/macadmins/nudge/blob/main/assets/NudgeIconInverted.png?raw=true</string>
 		<key>iconLightPath</key>
 		<string>https://github.com/macadmins/nudge/blob/main/assets/NudgeIcon.png?raw=true</string>
-		<key>screenShotDarkPath</key>
-		<string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_dark_1_icon.png?raw=true</string>
-		<key>screenShotLightPath</key>
-		<string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_light_1_icon.png?raw=true</string>
-		<key>simpleMode</key>
-		<false/>
-		<key>updateElements</key>
-		<array>
+                <key>screenShotDarkPath</key>
+                <string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_dark_1_icon.png?raw=true</string>
+                <key>screenShotLightPath</key>
+                <string>https://github.com/macadmins/nudge/blob/main/assets/standard_mode/demo_light_1_icon.png?raw=true</string>
+                <key>showRequiredDate</key>
+                <true/>
+                <key>simpleMode</key>
+                <false/>
+                <key>simpleModeOptions</key>
+                <dict>
+                        <key>showRequiredDate</key>
+                        <true/>
+                        <key>showRequiredOSVersion</key>
+                        <true/>
+                        <key>showRequiredTime</key>
+                        <true/>
+                </dict>
+                <key>updateElements</key>
+                <array>
 			<dict>
 				<key>_language</key>
 				<string>en</string>

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -626,6 +626,40 @@ struct UserInterfaceVariables {
         false
     }
 
+    static var simpleModeEnabled: Bool {
+        if let simpleMode = userInterfaceProfile?["simpleMode"] as? Bool {
+            return simpleMode
+        }
+        return userInterfaceJSON?.simpleMode ?? false
+    }
+
+    static var simpleModeShowRequiredDate: Bool {
+        guard simpleModeEnabled else { return false }
+        if let options = userInterfaceProfile?["simpleModeOptions"] as? [String: Any],
+           let value = options["showRequiredDate"] as? Bool {
+            return value
+        }
+        return userInterfaceJSON?.simpleModeOptions?.showRequiredDate ?? false
+    }
+
+    static var simpleModeShowRequiredOSVersion: Bool {
+        guard simpleModeEnabled else { return false }
+        if let options = userInterfaceProfile?["simpleModeOptions"] as? [String: Any],
+           let value = options["showRequiredOSVersion"] as? Bool {
+            return value
+        }
+        return userInterfaceJSON?.simpleModeOptions?.showRequiredOSVersion ?? false
+    }
+
+    static var simpleModeShowRequiredTime: Bool {
+        guard simpleModeEnabled else { return false }
+        if let options = userInterfaceProfile?["simpleModeOptions"] as? [String: Any],
+           let value = options["showRequiredTime"] as? Bool {
+            return value
+        }
+        return userInterfaceJSON?.simpleModeOptions?.showRequiredTime ?? false
+    }
+
     static var singleQuitButton: Bool {
         userInterfaceProfile?["singleQuitButton"] as? Bool ??
         userInterfaceJSON?.singleQuitButton ??

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -458,8 +458,13 @@ struct UserInterface: Codable {
     var actionButtonPath, applicationTerminatedNotificationImagePath, fallbackLanguage: String?
     var forceFallbackLanguage, forceScreenShotIcon: Bool?
     var iconDarkPath, iconLightPath, requiredInstallationDisplayFormat, screenShotDarkPath, screenShotLightPath: String?
-    var showActivelyExploitedCVEs, showDeferralCount, showDaysRemainingToUpdate, showRequiredDate, simpleMode, singleQuitButton: Bool?
+    var showActivelyExploitedCVEs, showDeferralCount, showDaysRemainingToUpdate, showRequiredDate, singleQuitButton: Bool?
+    var simpleMode: Bool?
+    var simpleModeOptions: SimpleModeOptions?
     var updateElements: [UpdateElement]?
+}
+struct SimpleModeOptions: Codable {
+    var showRequiredDate, showRequiredOSVersion, showRequiredTime: Bool?
 }
 
 // MARK: UserInterface convenience initializers and mutators
@@ -496,6 +501,7 @@ extension UserInterface {
         showDaysRemainingToUpdate: Bool? = nil,
         showRequiredDate: Bool? = nil,
         simpleMode: Bool? = nil,
+        simpleModeOptions: SimpleModeOptions? = nil,
         singleQuitButton: Bool? = nil,
         updateElements: [UpdateElement]? = nil
     ) -> UserInterface {
@@ -515,6 +521,7 @@ extension UserInterface {
             showDaysRemainingToUpdate: showDaysRemainingToUpdate ?? self.showDaysRemainingToUpdate,
             showRequiredDate: showRequiredDate ?? self.showRequiredDate,
             simpleMode: simpleMode ?? self.simpleMode,
+            simpleModeOptions: simpleModeOptions ?? self.simpleModeOptions,
             singleQuitButton: singleQuitButton ?? self.singleQuitButton,
             updateElements: updateElements ?? self.updateElements
         )

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -32,7 +32,15 @@ struct SimpleMode: View {
             
             Text(appState.deviceSupportedByOSVersion ? getMainHeader().localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)) : getMainHeaderUnsupported().localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
                 .font(.title)
-            
+
+            if UserInterfaceVariables.simpleModeShowRequiredOSVersion {
+                requiredOSVersionView
+            }
+
+            if UserInterfaceVariables.simpleModeShowRequiredDate {
+                requiredDateView
+            }
+
             remainingTimeView
 
             if UserInterfaceVariables.showDeferralCount {
@@ -84,6 +92,45 @@ struct SimpleMode: View {
                 .foregroundColor(infoTextColor)
                 .font(.title2)
         }
+    }
+
+    private var requiredOSVersionView: some View {
+        HStack {
+            Text("Required OS Version:".localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
+            Text(String(appState.requiredMinimumOSVersion))
+                .foregroundColor(infoTextColor)
+        }
+    }
+
+    private var requiredDateView: some View {
+        HStack {
+            Text("Required Date:".localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
+            Text(requiredDateText)
+                .foregroundColor(infoTextColor)
+        }
+    }
+
+    private var requiredDateText: String {
+        let localeIdentifier = getDesiredLanguage(locale: appState.locale)
+        let locale = Locale(identifier: localeIdentifier)
+        let format = UserInterfaceVariables.requiredInstallationDisplayFormat
+        let dateText = DateManager().coerceDateToString(
+            date: requiredInstallationDate,
+            formatterString: format,
+            locale: locale
+        )
+
+        if UserInterfaceVariables.simpleModeShowRequiredTime && !formatIncludesTime(format) {
+            let timeText = DateManager().coerceTimeToString(date: requiredInstallationDate, locale: locale)
+            return "\(dateText) \(timeText)"
+        }
+
+        return dateText
+    }
+
+    private func formatIncludesTime(_ format: String) -> Bool {
+        let timeCharacters = CharacterSet(charactersIn: "HhKkmsaS")
+        return format.rangeOfCharacter(from: timeCharacters) != nil
     }
     
     private var bottomButtons: some View {

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -391,6 +391,5 @@ func getMainHeaderUnsupported() -> String {
 
 func simpleMode() -> Bool {
     return CommandLineUtilities().simpleModeEnabled() ||
-    UserInterfaceVariables.userInterfaceProfile?["simpleMode"] as? Bool ??
-    Globals.nudgeJSONPreferences?.userInterface?.simpleMode ?? false
+    UserInterfaceVariables.simpleModeEnabled
 }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -574,6 +574,14 @@ struct DateManager {
         }
     }
 
+    func coerceTimeToString(date: Date, locale: Locale? = nil) -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateStyle = .none
+        timeFormatter.timeStyle = .short
+        timeFormatter.locale = locale ?? Locale.current
+        return timeFormatter.string(from: date)
+    }
+
     func coerceStringToDate(dateString: String) -> Date {
         if dateString.contains("Z") {
             dateFormatterISO8601.date(from: dateString) ?? getCurrentDate()

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For more information about installation, deployment, and the user experience, pl
 
 # Examples of the User Interface
 ## simpleMode
+SimpleMode offers a streamlined experience and can optionally display the required OS version, due date, and deadline time. Enable simple mode with the top-level `simpleMode` key and configure the `simpleModeOptions` dictionary with the `showRequiredOSVersion`, `showRequiredDate`, and `showRequiredTime` keys to control this behavior.
 ### English
 #### Light
 <img src="/assets/simple_mode/demo_simple_light_1.png" width=75% height=75%>

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -1451,6 +1451,54 @@
                                 }
                             ]
                         },
+                        "simpleModeOptions": {
+                            "description": "Configuration options for the simplified user experience.",
+                            "type": "object",
+                            "properties": {
+                                "showRequiredDate": {
+                                    "description": "When enabled, Nudge will show the requiredInstallationDate when using simpleMode.",
+                                    "anyOf": [
+                                        {
+                                            "title": "Not Configured",
+                                            "type": "null"
+                                        },
+                                        {
+                                            "title": "Configured",
+                                            "default": false,
+                                            "type": "boolean"
+                                        }
+                                    ]
+                                },
+                                "showRequiredOSVersion": {
+                                    "description": "When enabled, Nudge will show the requiredMinimumOSVersion when using simpleMode.",
+                                    "anyOf": [
+                                        {
+                                            "title": "Not Configured",
+                                            "type": "null"
+                                        },
+                                        {
+                                            "title": "Configured",
+                                            "default": false,
+                                            "type": "boolean"
+                                        }
+                                    ]
+                                },
+                                "showRequiredTime": {
+                                    "description": "When enabled, Nudge will include the time component of requiredInstallationDate when using simpleMode.",
+                                    "anyOf": [
+                                        {
+                                            "title": "Not Configured",
+                                            "type": "null"
+                                        },
+                                        {
+                                            "title": "Configured",
+                                            "default": false,
+                                            "type": "boolean"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
                         "singleQuitButton": {
                             "description": "Only display one quit button regardless of proximity to the due date.",
                             "anyOf": [


### PR DESCRIPTION
## Summary
- keep `simpleMode` as a top-level boolean for backward compatibility
- add a `simpleModeOptions` dictionary with `showRequiredOSVersion`, `showRequiredDate`, and `showRequiredTime`
- adjust preference helpers, SwiftUI, schema, examples, and documentation accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_i_68992140bf78832baa5da9bf856f57f7